### PR TITLE
Add Next.js Gemini demo implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env.local

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-> this is a demo app on video process
+# Video Analyzer Demo
+
+This is a minimal Next.js 14 demo that uploads a short basketball video to
+Vercel Blob storage and sends the clip to Gemini 2.5 Flash for analysis.
+The JSON result is displayed next to the uploaded video.
+
+## Getting Started
+
+1. Install dependencies and run the development server:
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+2. Create a `.env.local` file with the following variables:
+   ```bash
+   VERCEL_BLOB_READ_WRITE_TOKEN=YOUR_TOKEN
+   GEMINI_API_KEY=YOUR_API_KEY
+   ```
+
+## Project Structure
+
+- `src/app/page.tsx` – front‑end page that handles upload and displays results.
+- `src/app/api/upload/route.ts` – edge function to create a Vercel Blob upload URL.
+- `src/app/api/process/route.ts` – edge function that calls Gemini.
+
+This demo omits error handling and authentication for brevity.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: { serverActions: true },
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "video-analyzer-demo",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@google/generative-ai": "^0.4.1",
+    "@vercel/blob": "latest"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.31",
+    "tailwindcss": "3.4.0",
+    "typescript": "5.2.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/api/process/route.ts
+++ b/src/app/api/process/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+export const runtime = 'edge';
+
+const genai = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
+
+export async function POST(req: NextRequest) {
+  const { blobUrl } = await req.json();
+
+  const model = genai.getGenerativeModel({ model: 'gemini-2.5-flash' });
+  const schema = {
+    name: 'shotResult',
+    parameters: {
+      type: 'object',
+      properties: {
+        made: { type: 'boolean' },
+        advice: { type: 'string' },
+      },
+      required: ['made', 'advice'],
+    },
+  };
+
+  const resp = await model.generateContent({
+    contents: [
+      { modality: 'VIDEO', uri: blobUrl },
+      { modality: 'TEXT', text: 'Analyse this basketball shot. Return JSON.' },
+    ],
+    tools: [schema],
+    systemInstruction: 'Return succinct coaching.',
+  });
+
+  return NextResponse.json(resp.toolResponses[0]);
+}

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,9 @@
+import { createUploadUrl } from '@vercel/blob/server';
+import { NextResponse } from 'next/server';
+
+export const runtime = 'edge';
+
+export async function POST() {
+  const { url, token } = await createUploadUrl();
+  return NextResponse.json({ url, token });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,16 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'AI Shot Coach',
+  description: 'Analyze basketball shot videos with Gemini',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { useState } from 'react';
+import './globals.css';
+
+export default function Home() {
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<any>();
+  const [videoUrl, setVideoUrl] = useState('');
+
+  async function upload(file: File) {
+    setLoading(true);
+    const { url, token } = await fetch('/api/upload', { method: 'POST' }).then(r => r.json());
+    await fetch(url, { method: 'PUT', headers: { 'x-vercel-blob-token': token }, body: file });
+    const res = await fetch('/api/process', { method: 'POST', body: JSON.stringify({ blobUrl: url }) }).then(r => r.json());
+    setVideoUrl(url);
+    setResult(res);
+    setLoading(false);
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-slate-100">
+      <div className="w-[650px] bg-white shadow rounded-2xl p-8 space-y-6">
+        <h1 className="text-2xl font-semibold">AI Shot Coach</h1>
+        {!result && (
+          <label className="flex flex-col items-center justify-center h-64 border-2 border-dashed rounded-xl bg-slate-50 cursor-pointer">
+            <input type="file" accept="video/*" hidden onChange={e => e.target.files && upload(e.target.files[0])} />
+            <p className="text-slate-500">Drag video or click to upload</p>
+          </label>
+        )}
+        {loading && <div className="h-1 w-full bg-slate-200 rounded"><div className="h-full w-2/3 bg-sky-500 animate-pulse" /></div>}
+        {result && (
+          <div className="grid grid-cols-2 gap-4">
+            <video className="rounded-xl" src={videoUrl} controls poster={videoUrl + '#t=0.1'} />
+            <pre className="border rounded-xl p-4 text-sm overflow-auto">{JSON.stringify(result, null, 2)}</pre>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- setup minimal Next.js project with Tailwind
- implement upload and process API routes
- add simple client page with upload and result view
- document environment variables in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683b4b82d85c8323a7eba6420ed7bbb9